### PR TITLE
Upgrade PackageReference prometheus-net to Version="2.1.3"

### DIFF
--- a/NetGrpcPrometheus/NetGrpcPrometheus.csproj
+++ b/NetGrpcPrometheus/NetGrpcPrometheus.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.5.1" />
     <PackageReference Include="Grpc" Version="1.10.0" />
-    <PackageReference Include="prometheus-net" Version="2.0.0" />
+    <PackageReference Include="prometheus-net" Version="2.1.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
fixes the metrics uppercase problem
see also https://github.com/e-conomic/csharp-grpc-prometheus/issues/10