### PR TITLE
Make implementation independent

### DIFF
--- a/NetGrpcPrometheus/NetGrpcPrometheus.csproj
+++ b/NetGrpcPrometheus/NetGrpcPrometheus.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.18.1" />
-    <PackageReference Include="Grpc" Version="2.27.0" />
+    <PackageReference Include="Grpc.Core.Api" Version="2.40.0" />
     <PackageReference Include="prometheus-net" Version="3.4.0" />
   </ItemGroup>
 

--- a/NetGrpcPrometheusTest/NetGrpcPrometheusTest.csproj
+++ b/NetGrpcPrometheusTest/NetGrpcPrometheusTest.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Grpc.Core" Version="2.40.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />


### PR DESCRIPTION
Google has [deprecated](1) its C# gRPC implementation (`Grpc.Core`) that is
based on the native C library in favor of the Microsoft implementation.

Fortunately, both implementations share the same type definitions to ensure
an easy migration. Because this library only needs the types defined in this
shared package, it is sufficient to only take this minimal dependency to make
the prometheus interceptor library implementation independent.

The test project can stay dependent on the full google implementation.

[1] https://grpc.io/blog/grpc-csharp-future/