### PR TITLE
Map unhandled exceptions to StatusCode.Internal

### DIFF
--- a/NetGrpcPrometheus/ServerInterceptor.cs
+++ b/NetGrpcPrometheus/ServerInterceptor.cs
@@ -57,6 +57,11 @@ namespace NetGrpcPrometheus
                 _metrics.ResponseCounterInc(method, e.Status.StatusCode);
                 throw;
             }
+            catch (Exception)
+            {
+                _metrics.ResponseCounterInc(method, StatusCode.Internal);
+                throw;
+            }
             finally
             {
                 watch.Stop();
@@ -89,6 +94,11 @@ namespace NetGrpcPrometheus
             catch (RpcException e)
             {
                 _metrics.ResponseCounterInc(method, e.Status.StatusCode);
+                throw;
+            }
+            catch (Exception)
+            {
+                _metrics.ResponseCounterInc(method, StatusCode.Internal);
                 throw;
             }
             finally
@@ -129,6 +139,11 @@ namespace NetGrpcPrometheus
                 _metrics.ResponseCounterInc(method, e.Status.StatusCode);
                 throw;
             }
+            catch (Exception)
+            {
+                _metrics.ResponseCounterInc(method, StatusCode.Internal);
+                throw;
+            }
             finally
             {
                 watch.Stop();
@@ -167,6 +182,11 @@ namespace NetGrpcPrometheus
             catch (RpcException e)
             {
                 _metrics.ResponseCounterInc(method, e.Status.StatusCode);
+                throw;
+            }
+            catch (Exception)
+            {
+                _metrics.ResponseCounterInc(method, StatusCode.Internal);
                 throw;
             }
             finally


### PR DESCRIPTION
If a gRPC server method throws an unhandled Exception, this will be mapped by the gRPC framework to "StatusCode.Internal". Make sure to register it as such in the metrics.